### PR TITLE
Increase content width and emphasize links

### DIFF
--- a/_sass/color_schemes/c2sm.scss
+++ b/_sass/color_schemes/c2sm.scss
@@ -6,7 +6,7 @@ $link-color: $c2sm-blue-dark;
 $header-height: 5.75rem;
 $content-width: 57.5rem;
 
-.main-content p, .main-content hr, .main-content ul, div.highlighter-rouge {
+h1, h2, h3, h4, h5, h6, .main-content p, .main-content hr, .main-content ul, div.highlighter-rouge {
     margin-right: 7.5em;
   }
 


### PR DESCRIPTION
The content width is increased to have some tables in datasets to be displayed entirely (without having to scroll horizontally). The widths of the actual paragraphs, images, etc. remain the same as before.

In addition, the link underlines are stronger now for better visibility (similar to GitHub style).

Closes https://github.com/C2SM/c2sm.github.io/issues/83