### PR TITLE
update cscs docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,33 @@ For full documentation visit [mkdocs.org](https://www.mkdocs.org).
 
 For full documentation visit https://squidfunk.github.io/mkdocs-material/.
 
-### Install
+### Quick Start
+
+> [!IMPORTANT]
+> to run the serve script, you need to first install [uv](https://docs.astral.sh/uv/getting-started/installation/).
+
+To quickly generate a view of the documenation
+
+Clone this repository on your PC/laptop, then view the documentation in a browser run `./serve`:
+
+```console
+$ git clone git@github.com:${githubusername}/c2sm.github.io.git
+$ cd c2sm.github.io.git
+./serve
+...
+INFO    -  [08:33:34] Serving on http://127.0.0.1:8000/
+```
+
+This generates the documentation locally, which can be viewed using a local link, typically [http://127.0.0.1:8000/](http://127.0.0.1:8000/). The documentation will be rebuilt and the webpage reloaded when changed files are saved.
+
+To build the docs in a `site` sub-directory:
+```bash
+./serve build
+```
+
+### Using MkDocs Manually
+
+First install MkDocs
 
 ```
 python3 -m venv venv
@@ -16,14 +42,14 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-### Commands
+The following commands are available:
 
 * `mkdocs new [dir-name]` - Create a new project.
 * `mkdocs serve` - Start the live-reloading docs server (open second terminal to make changes).
 * `mkdocs build` - Build the documentation site.
 * `mkdocs -h` - Print help message and exit.
 
-### Project layout
+## Project layout
 
     mkdocs.yml    # The configuration file.
     docs/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Clone this repository on your PC/laptop, then view the documentation in a browse
 
 ```console
 $ git clone git@github.com:${githubusername}/c2sm.github.io.git
-$ cd c2sm.github.io.git
+$ cd c2sm.github.io
 ./serve
 ...
 INFO    -  [08:33:34] Serving on http://127.0.0.1:8000/

--- a/docs/alps/index.md
+++ b/docs/alps/index.md
@@ -1,10 +1,10 @@
 # The Alps System
 
-Alps is a distributed HPC infrastructure managed by CSCS. Contrary to traditional HPC, it is composed of several logical units called vClusters (versatile clusters). From the users perspective, they play the role of a traditional HPC machine, each vCluster being tailored to the needs of a specific community. This setup also enables geographical distribution of vClusters which facilitates geo-redundancy. The main physical piece of Alps is hosted at CSCS in Lugano and a detailed description can be found at [their website :material-open-in-new:](https://www.cscs.ch/computers/alps){:target="_blank"}.
+Alps is a distributed HPC infrastructure managed by CSCS. Contrary to traditional HPC, it is composed of several logical units called vClusters (versatile clusters). From the users perspective, they play the role of a traditional HPC machine, each vCluster being tailored to the needs of a specific community. This setup also enables geographical distribution of vClusters which facilitates geo-redundancy. The main physical piece of Alps is hosted at CSCS in Lugano and a detailed description can be found at [their documenation :material-open-in-new:](https://docs.cscs.ch/alps/){:target="_blank"}.
 
 ## vClusters
 
-The following table shows current vClusters distribution on Alps at CSCS (only C2SM relevant vClusters are shown).
+The following table shows current clusters distribution on Alps at CSCS (only C2SM relevant clusters are shown).
 
 | vCluster | Activity          | Share            |
 |----------|-------------------|------------------|
@@ -15,9 +15,11 @@ The following table shows current vClusters distribution on Alps at CSCS (only C
 
 *GH = Grace Hopper*
 
+More information about clusters on Alps is available on the [official CSCS documentation :material-open-in-new:](https://docs.cscs.ch/alps/clusters/#alps-clusters){:target="_blank"}.
+
 ## Support by CSCS
 
-General information about access, file systems, vClusters, user environments and much more can be found at the [CSCS Knowledge Base :material-open-in-new:](https://confluence.cscs.ch/display/KB){:target="_blank"}.
+General information about access, file systems, vClusters, user environments and much more can be found at the [CSCS documentation :material-open-in-new:](https://docs.cscs.ch/){:target="_blank"}.
 
 To contact CSCS staff directly, users can join their dedicated [Slack workspace :material-open-in-new:](https://cscs-users.slack.com){:target="_blank"}, with dedicated channels for each vCluster. 
 

--- a/docs/alps/uenvs.md
+++ b/docs/alps/uenvs.md
@@ -11,10 +11,10 @@ Software stacks at CSCS are now accessible through the so-called User Environmen
     - upgrading to more recent software stacks or keeping old ones around (think compiler versions) is way easier
     - users (for now C2SM) are able to build their own uenvs
     - quicker access to software compared to classical multi-files directories
-    
+
 ## CSCS documentation
 
-A description of user environments and the `uenv` tool can be found in the [CSCS Knowledge Base :material-open-in-new:](https://confluence.cscs.ch/display/KB/UENV+user+environments){:target="_blank"}. 
+A description of user environments and the `uenv` tool can be found in the [CSCS documentation :material-open-in-new:](https://docs.cscs.ch/software/uenv/){:target="_blank"}. 
 
 ## Uenvs central Registry and C2SM uenvs
 
@@ -26,7 +26,7 @@ The user environments provided by CSCS are registered in a central database. In 
 
 ## The `uenv` command line tool
 
-[Official documentation :material-open-in-new:](https://eth-cscs.github.io/uenv/){:target="_blank"}
+[Official documentation :material-open-in-new:](https://docs.cscs.ch/software/uenv/){:target="_blank"}
 
 It can be used to
 

--- a/docs/models/icon/icon-clm.md
+++ b/docs/models/icon/icon-clm.md
@@ -26,7 +26,7 @@ tailored for ICON-CLM simulations.
     Be sure that `CLUSTER_NAME=todi` is **not** present anywhere (e.g. in your `~/.bashrc`) as it is not needed anymore.
     The two uenvs we need are available on santis.
 
-    For more information about uenvs, see [here :material-open-in-new:](https://confluence.cscs.ch/spaces/KB/pages/701726829/uenv+user+environments){:target="_blank"}.
+    For more information about uenvs, see [the CSCS documentation :material-open-in-new:](https://docs.cscs.ch/software/uenv){:target="_blank"}.
 
 Load the `netcdf-tools` uenv:
 

--- a/serve
+++ b/serve
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# use uv to run mkdocs with mkdocs-material and its dependencies installed
+uv tool run --with-requirements ./requirements.txt mkdocs ${@:-serve}


### PR DESCRIPTION
CSCS has new documentation, that replaces the KB.
* update links to old docs to the new documentation (also written in Material for MkDocs)

I also added a little `uv` powered tool for quickly starting a server without having to mess around with pip:
Type:
```
./serve
```
And uv will set up the environment and start the server