### PR TITLE
Move EvaSuite to SPICE

### DIFF
--- a/docs/models/icon/icon-clm.md
+++ b/docs/models/icon/icon-clm.md
@@ -1,5 +1,9 @@
 # ICON-CLM Workflow for EURO-CORDEX 12 km Domain
 
+!!! warning 
+
+    Information provided here is outdated since Santis, uenvs and SPICE have received updates.
+
 ## SPICE
 
 [SPICE](../../tools/spice.md) is a software created by the CLM community and serves as a processing chain / workflow tool

--- a/docs/tools/SUMMARY.md
+++ b/docs/tools/SUMMARY.md
@@ -1,6 +1,5 @@
 * [Tools](index.md)
 * [DWD ICON Tools](icontools.md)
-* [EvaSuite](evasuite.md)
 * [EXTPAR](extpar.md)
 * [Processing Chain](processing_chain.md)
 * [Scaling Analysis](scaling_analysis.md)

--- a/docs/tools/SUMMARY.md
+++ b/docs/tools/SUMMARY.md
@@ -3,7 +3,7 @@
 * [EXTPAR](extpar.md)
 * [Processing Chain](processing_chain.md)
 * [Scaling Analysis](scaling_analysis.md)
-* [Spack](spack.md)
+* [Spack-C2SM](spack.md)
 * [SPICE](spice.md)
 * [Zephyr](zephyr.md)
 * [Zonda](zonda.md)

--- a/docs/tools/extpar.md
+++ b/docs/tools/extpar.md
@@ -1,6 +1,6 @@
 # EXTPAR
 
-EXTPAR (**Ext**ernal **Par**ameters for Numerical Weather Prediction and Climate Application)
+[EXTPAR :material-open-in-new:](https://github.com/C2SM/extpar){:target="_blank"} (**Ext**ernal **Par**ameters for Numerical Weather Prediction and Climate Application)
 is used to prepare the external parameter data files that are used as input for the ICON model.
 
 All information around this software can be found in the

--- a/docs/tools/icontools.md
+++ b/docs/tools/icontools.md
@@ -29,7 +29,7 @@ uenv start climtools/25.2:v1 --view=climtools
 please consider the official [spack-c2sm documentation :material-open-in-new:](https://c2sm.github.io/spack-c2sm/latest){:target="_blank"}.
 The following Spack installation should be sufficient for most cases.
 
-Clone the C2SM Spack main branch and source it:
+Clone the Spack-C2SM main branch and source it:
 ```bash
 git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/C2SM/spack-c2sm.git
 source ./spack-c2sm/setup-env.sh /user-environment

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -37,14 +37,6 @@ C2SM supports a set of pre- and postprocessing tools on different high-performan
 
     [:octicons-arrow-right-24: SPICE](spice.md)
 
--   :material-check-circle-outline:{ .lg .middle } **EvaSuite**
-
-    ---
-
-    Addon for SPICE and standalone tool for comparing simulation experiments with E-OBS or ERA5.
-
-    [:octicons-arrow-right-24: EvaSuite](evasuite.md)
-
 -   :material-pipe:{ .lg .middle } **Processing Chain**
 
     ---

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -57,7 +57,7 @@ C2SM supports a set of pre- and postprocessing tools on different high-performan
 
     C2SM's configuration of the Spack package manager for installing ICON and related software on HPC systems.
 
-    [:octicons-arrow-right-24: Spack](spack.md)
+    [:octicons-arrow-right-24: Spack-C2SM](spack.md)
 
 -   :material-chart-bar:{ .lg .middle } **Scaling Analysis**
 

--- a/docs/tools/spack.md
+++ b/docs/tools/spack.md
@@ -1,5 +1,5 @@
 # Spack-C2SM
 
-Spack-C2SM is the package management system maintained by C2SM and MeteoSwiss for installing and deploying scientific software on high-performance computing systems, primarily at the Swiss National Supercomputing Centre (CSCS). Built on top of [Spack :material-open-in-new:](https://spack.io){:target="_blank"}, it provides environment management, package discovery, and installation workflows tailored to the C2SM community. It supports different use cases — from simply installing pre-built packages to actively developing and building model code with commands like `spack dev-build`.
+Spack-C2SM is the package management system maintained by C2SM and MeteoSwiss for installing and deploying scientific software on high-performance computing systems, primarily at the Swiss National Supercomputing Centre (CSCS). Built on top of [Spack :material-open-in-new:](https://spack.io){:target="_blank"}, it provides environment management, package discovery, and installation workflows tailored to the C2SM community. It supports different use cases — from simply installing pre-built packages to actively developing and building model code.
 
 Find all information about the C2SM version of Spack in the [official Spack-C2SM documentation :material-open-in-new:](https://c2sm.github.io/spack-c2sm/latest){:target="_blank"}.

--- a/docs/tools/spack.md
+++ b/docs/tools/spack.md
@@ -1,5 +1,5 @@
 # Spack-C2SM
 
-Spack-C2SM is the package management system maintained by C2SM and MeteoSwiss for installing and deploying scientific software on high-performance computing systems, primarily at the Swiss National Supercomputing Centre (CSCS). Built on top of [Spack](https://spack.io), it provides environment management, package discovery, and installation workflows tailored to the C2SM community. It supports different use cases — from simply installing pre-built packages to actively developing and building model code with commands like `spack dev-build`.
+Spack-C2SM is the package management system maintained by C2SM and MeteoSwiss for installing and deploying scientific software on high-performance computing systems, primarily at the Swiss National Supercomputing Centre (CSCS). Built on top of [Spack :material-open-in-new:](https://spack.io){:target="_blank"}, it provides environment management, package discovery, and installation workflows tailored to the C2SM community. It supports different use cases — from simply installing pre-built packages to actively developing and building model code with commands like `spack dev-build`.
 
 Find all information about the C2SM version of Spack in the [official Spack-C2SM documentation :material-open-in-new:](https://c2sm.github.io/spack-c2sm/latest){:target="_blank"}.

--- a/docs/tools/spack.md
+++ b/docs/tools/spack.md
@@ -1,3 +1,3 @@
-# C2SM Spack
+# Spack-C2SM
 
-Find all information about the C2SM version of Spack in the [official C2SM Spack documentation :material-open-in-new:](https://c2sm.github.io/spack-c2sm/latest){:target="_blank"}.
+Find all information about the C2SM version of Spack in the [official Spack-C2SM documentation :material-open-in-new:](https://c2sm.github.io/spack-c2sm/latest){:target="_blank"}.

--- a/docs/tools/spack.md
+++ b/docs/tools/spack.md
@@ -1,3 +1,5 @@
 # Spack-C2SM
 
+Spack-C2SM is the package management system maintained by C2SM and MeteoSwiss for installing and deploying scientific software on high-performance computing systems, primarily at the Swiss National Supercomputing Centre (CSCS). Built on top of [Spack](https://spack.io), it provides environment management, package discovery, and installation workflows tailored to the C2SM community. It supports different use cases — from simply installing pre-built packages to actively developing and building model code with commands like `spack dev-build`.
+
 Find all information about the C2SM version of Spack in the [official Spack-C2SM documentation :material-open-in-new:](https://c2sm.github.io/spack-c2sm/latest){:target="_blank"}.

--- a/docs/tools/spice.md
+++ b/docs/tools/spice.md
@@ -18,3 +18,133 @@ For any questions, please contact [Michael Jähn :material-open-in-new:](https:/
 ## Documentation
 
 * [SPICE Docs :material-open-in-new:](https://spice.clm-community.eu/){:target="_blank"}
+
+
+## EvaSuite
+
+EvaSuite is an addon for SPICE but also a standalone software for either
+
+1. Compare your simulation experiment with E-OBS or ERA5.
+2. Compare your simulation experiment and a reference simulation with E-OBS or ERA5.
+
+### Instructions to Set Up on Säntis
+
+!!! warning "Instructions partly outdated"
+
+    Due to the latest updates of EvaSuite, there is no official support on Santis.
+    The instructions below may still be valid, but could also be partly outdated.
+    In any case, please refer to the official EvaSuite Documentation.
+
+#### Setup Miniforge
+
+EvaSuite needs a conda environment setup to run properly. On a HPC system as Alps/Säntis,
+Conda's packages and environments should be installed on `$SCRATCH` in order to not run into the file quota limit.
+Miniforge itself can be installed in `$HOME`.
+
+**Download Miniforge for aarch64**
+
+```bash
+cd ~
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh
+```
+
+**Install Miniforge into your home directory**
+
+```bash
+Miniforge3-Linux-aarch64.sh -b -p $HOME/miniforge3
+```
+
+**Add Miniforge to your PATH**
+
+```bash
+echo 'export PATH=$HOME/miniforge3/bin:$PATH' >> ~/.bashrc
+```
+
+**Configure Conda to store envs/pkgs on `$SCRATCH`**
+
+Create `~/.condarc`:
+
+```yaml
+channels:
+  - conda-forge
+channel_priority: strict
+
+envs_dirs:
+  - $SCRATCH/conda_envs
+pkgs_dirs:
+  - $SCRATCH/conda_pkgs
+
+auto_activate_base: false
+```
+
+uenv and modules:
+
+```bash
+uenv start --view=modules netcdf-tools/2024:v1
+module load gcc/13.2.0 hdf5/1.14.3
+``` 
+
+Base environment:
+
+```bash
+conda create -n py310_evasuite python=3.10 -y
+conda activate py310_evasuite
+```
+
+Installing packages:
+
+```bash
+conda install -c conda-forge fiona cartopy rasterio h5py psutil
+```
+
+#### Installation
+
+Follow `DOCS/installation.md`:
+
+1. **Clone the repository**
+```bash
+git clone --recurse-submodules https://gitlab.dkrz.de/clm-community/public/evasuite.git EvaSuite_v1.0
+```
+
+
+
+2. **Create and activate a Python virtual environment within the EvaSuite repo**
+```bash
+cd EvaSuite_v1.0
+conda activate py310_evasuite
+```
+
+3. **Tell pip to Use `$SCRATCH` for Cache & Wheels**
+
+```bash
+export PIP_CACHE_DIR=$SCRATCH/pip_cache
+export TMPDIR=$SCRATCH/pip_temp
+mkdir -p $PIP_CACHE_DIR $TMPDIR
+```
+
+4. **Upgrade pip and install dependencies**
+```bash
+pip install --upgrade pip setuptools wheel
+pip install -r requirements.txt
+```
+
+5. **Install EvaSuite**
+```bash
+pip install .
+```
+
+
+### Usage
+
+Load modules and activate environment:
+```bash
+uenv start --view=modules netcdf-tools/2024:v1
+module load cdo/2.4.0 netcdf-c/4.9.2 netcdf-fortran/4.6.1
+conda activate py310_evasuite
+```
+
+### Reference
+
+- [PDF Documentation :material-open-in-new:](https://gitlab.dkrz.de/clm-community/public/evasuite/-/raw/main/DOCS/Documentation_EvaSuite_v1_0.pdf?ref_type=heads&inline=true){:target="_blank"}
+- [EvaSuite within SPICE User Guide :material-open-in-new:](https://clm-community.gitlab-pages.dkrz.de/public/spice/add-ons/eva-suite.html){:target="_blank"}
+- [Public repository on GitLab :material-open-in-new:](https://gitlab.dkrz.de/clm-community/public/evasuite){:target="_blank"}


### PR DESCRIPTION
EvaSuite should not be listed as official tool supported by C2SM because:

- it is not tested / supported
- even though it is a standalone, it is closely tied to SPICE

Hence, we move it under the SPICE section.